### PR TITLE
Agregar tests para casos no palíndromos

### DIFF
--- a/tests/test_palindrome.py
+++ b/tests/test_palindrome.py
@@ -13,6 +13,11 @@ class TestPalindrome(unittest.TestCase):
         self.assertTrue(is_palindrome("Was it a car or a cat I saw?"))
         self.assertTrue(is_palindrome("No lemon, no melon"))
 
+    def test_non_palindromes(self):
+        self.assertFalse(is_palindrome("hello"))
+        self.assertFalse(is_palindrome("python"))
+        self.assertFalse(is_palindrome("This is not a palindrome"))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Se agregaron casos de prueba para verificar que la función is_palindrome devuelva False ante entradas que no son palíndromos. Estas pruebas cubren palabras y frases comunes que deben ser correctamente rechazadas.

Closes #3
